### PR TITLE
refactor: use repo name as default image name

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,8 +14,8 @@ on:
   workflow_dispatch:
 
 env:
-  MY_IMAGE_NAME: "ublue-custom"  # the name of the image produced by this build
-  MY_IMAGE_DESC: "My Customized Universal Blue System Image"
+  MY_IMAGE_NAME: "${{ github.event.repository.name }}"  # the name of the image produced by this build, matches repo names
+  MY_IMAGE_DESC: "My Customized Universal Blue Image"
   IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"  # do not edit
 
 jobs:

--- a/Containerfile
+++ b/Containerfile
@@ -35,13 +35,13 @@ ARG SOURCE_IMAGE="silverblue"
 # - (and the above with testing rather than stable)
 ARG SOURCE_SUFFIX="-main"
 
-## FEDORA_VERSION arg must be a version built by ublue: eg, 39 or 40
-ARG FEDORA_VERSION="39"
+## SOURCE_TAG arg must be a version built for the specific image: eg, 39, 40, gts, latest
+ARG SOURCE_TAG="latest"
 
 
 ### 2. SOURCE IMAGE
 ## this is a standard Containerfile FROM using the build ARGs above to select the right upstream image
-FROM ghcr.io/ublue-os/${SOURCE_IMAGE}${SOURCE_SUFFIX}:${FEDORA_VERSION}
+FROM ghcr.io/ublue-os/${SOURCE_IMAGE}${SOURCE_SUFFIX}:${SOURCE_TAG}
 
 
 ### 3. MODIFICATIONS

--- a/README.md
+++ b/README.md
@@ -44,7 +44,7 @@ This file defines the operations used to customize the selected image. It contai
 
 ### build.yml
 
-This workflow creates your custom OCI image and publishes it to the Github Container Registry (GHCR).
+This workflow creates your custom OCI image and publishes it to the Github Container Registry (GHCR). By default, the image name will match the Github repository name.
 
 #### Container Signing
 


### PR DESCRIPTION
Also makes the source image's tag easier to understand in the Containerfile.