### PR TITLE
style: Remove RUN from commented command

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -16,7 +16,7 @@ RELEASE="$(rpm -E %fedora)"
 rpm-ostree install screen
 
 # this would install a package from rpmfusion
-#RUN rpm-ostree install vlc
+# rpm-ostree install vlc
 
 
 


### PR DESCRIPTION
I think it's a bit confusing to have `RUN` as part of the command, which looks more like a containerfile command than a shell command.