### PR TITLE
chore: update Node 16 actions to latest versions

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -31,7 +31,7 @@ jobs:
     steps:
       # Checkout push-to-registry action GitHub repository
       - name: Checkout Push to Registry action
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
 
       - name: Generate tags
         id: generate-tags
@@ -75,7 +75,7 @@ jobs:
 
       # Build metadata
       - name: Image Metadata
-        uses: docker/metadata-action@v4
+        uses: docker/metadata-action@v5
         id: meta
         with:
           images: |


### PR DESCRIPTION
That should get rid of the warnings during builds: "Node.js 16 actions are deprecated. Please update the following actions to use Node.js 20: actions/checkout@v3, docker/metadata-action@v4."