### PR TITLE
feat: create .gitignore with cosign.key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,1 @@
+cosign.key


### PR DESCRIPTION
It's quite easy to commit `cosign.key` by mistake by following the README, I think it'd make sense to add `cosign.key` to `.gitignore`.