### PR TITLE
feat(ci): buildah: del `disable-content-trust`, enable zstd compression; bump sigstore/cosign-installer to 3.7.0

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -132,7 +132,7 @@ jobs:
           username: ${{ env.REGISTRY_USER }}
           password: ${{ env.REGISTRY_PASSWORD }}
           extra-args: |
-            --disable-content-trust
+            --compression-format=zstd
 
       # This section is optional and only needs to be enabled if you plan on distributing
       # your project for others to consume. You will need to create a public and private key
@@ -140,7 +140,7 @@ jobs:
       # to consume. For more details, review the image signing section of the README.
 
       # Sign container
-      - uses: sigstore/cosign-installer@v3.5.0
+      - uses: sigstore/cosign-installer@v3.7.0
         if: github.event_name != 'pull_request'
 
       - name: Sign container image


### PR DESCRIPTION
* `--disable-content-trust` is not needed according to [buildah docs](https://github.com/containers/buildah/blob/main/docs/buildah-build.1.md).
* Enable `zstd` compression: Fedora 39 is EOL, our new friends will only use Fedora 40 or newer, beside the custom layer, it can also reduce the download size if upstream isn't using `zstd` like Bluefin. 
*  Bump sigstore/cosign-installer to 3.7.0