### PR TITLE
fix: remove bootc container lint check

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,6 +17,5 @@ COPY build.sh /tmp/build.sh
 
 RUN mkdir -p /var/lib/alternatives && \
     /tmp/build.sh && \
-    ostree container commit && \
-    bootc container lint
+    ostree container commit
     


### PR DESCRIPTION
This requires Composefs to be used, which we are not yet in a position to enable.
We need to wait until either bootc container lint allows us to exclude checks, or when the atomic desktops switch over to composefs.