### PR TITLE
fix: install packages via dnf5

### DIFF
--- a/build.sh
+++ b/build.sh
@@ -10,7 +10,7 @@ set -ouex pipefail
 # https://mirrors.rpmfusion.org/mirrorlist?path=free/fedora/updates/39/x86_64/repoview/index.html&protocol=https&redirect=1
 
 # this installs a package from fedora repos
-dnf install -y tmux 
+dnf5 install -y tmux 
 
 # Use a COPR Example:
 #


### PR DESCRIPTION
Some repos, such as Bazzite, change `dnf` to a no-op so end users don't try it and encounter an error when booted. 
Inside the Containerfile, we should default to `dnf5` until the wrapper is updated to detect when running in CI.

Fixes the issue seen in the SCaLE demo.