### PR TITLE
feat(build-iso): Add ability to generate ISO

### DIFF
--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -1,0 +1,92 @@
+---
+name: Build ISOs
+
+on:
+  workflow_dispatch:
+    inputs:
+      upload-to-s3:
+        description: "Upload to S3"
+        required: false
+        default: false
+        type: boolean
+  pull_request:
+    branches:
+      - main
+    paths:
+      - './iso.toml'
+      - './.github/workflows/build-iso.yml'
+      - './Justfile'
+
+env:
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
+  IMAGE_NAME: "yourimagename"
+  DEFAULT_TAG: "latest"
+  BUILD_ARCH: [ # You can control which architectures you build for by setting this variable
+    #arm64, 
+    amd64,
+    ]
+  S3_PROVIDER: "yours3provider" # Must be one of the following values:  
+  S3_BUCKET_NAME: "yourbucketname"
+
+concurrency:
+  group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
+  cancel-in-progress: true
+
+jobs:
+  build:
+    name: Build ISOs
+    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    strategy:
+      fail-fast: false
+      matrix:
+        platform: $BUILD_ARCH
+    permissions:
+      contents: read
+      packages: read
+      id-token: write
+
+    steps:
+      - name: Install dependencies
+        if: matrix.platform == 'arm64'
+        run: |
+          set -x
+          sudo apt update -y
+          sudo apt install -y \
+            podman
+
+      - name: Maximize build space
+        if: matrix.platform != 'arm64'
+        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+        with:
+          remove-codeql: true
+
+      - name: Checkout
+        uses: actions/checkout@11bd71901bbe5b1630ceea73d27597364c9af683 # v4
+
+      - name: Setup Just
+        uses: extractions/setup-just@dd310ad5a97d8e7b41793f8ef055398d51ad4de6 # v2
+
+      - name: Build ISO
+        id: build
+        uses: ublue-os/bootc-image-builder-action@main
+        with:
+          bootc-image-builder-image: ghcr.io/centos-workstation/bootc-image-builder:latest
+          use-librepo: true
+          config-file: ./iso.toml
+          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
+
+      - name: Upload to S3
+        if: inputs.upload-to-s3 == true && github.event_name != 'pull_request'
+        shell: bash
+        env:
+          RCLONE_CONFIG_S3_TYPE: s3
+          RCLONE_CONFIG_S3_PROVIDER: ${{ env.S3_PROVIDER }}
+          RCLONE_CONFIG_S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
+          RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
+          RCLONE_CONFIG_S3_REGION: ${{ secrets.S3_REGION }}
+          RCLONE_CONFIG_S3_ENDPOINT: ${{ secrets.S3_ENDPOINT }}
+          SOURCE_DIR: ${{ steps.build.outputs.output-directory }}
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y rclone
+          rclone copy $SOURCE_DIR S3:${{ env.S3_BUCKET_NAME }}

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -76,6 +76,16 @@ jobs:
           config-file: ./iso.toml
           image: ${{ env.IMAGE_REGISTRY }}:${{ env.DEFAULT_TAG }}
 
+      - name: Upload ISOs and Checksum to Job Artifacts
+        if: inputs.upload-to-s3 != true && github.event_name != 'pull_request'
+        uses: actions/upload-artifact@4cec3d8aa04e39d1a68397de0c4cd6fb9dce8ec1 # v4
+        with:
+          path: ${{ steps.build.outputs.output-directory }}
+          if-no-files-found: error
+          retention-days: 0
+          compression-level: 0
+          overwrite: true
+      
       - name: Upload to S3
         if: inputs.upload-to-s3 == true && github.event_name != 'pull_request'
         shell: bash

--- a/.github/workflows/build-iso.yml
+++ b/.github/workflows/build-iso.yml
@@ -9,6 +9,12 @@ on:
         required: false
         default: false
         type: boolean
+      platform:
+        required: true
+        type: choice
+        options:
+          - amd64
+          - arm64
   pull_request:
     branches:
       - main
@@ -18,15 +24,8 @@ on:
       - './Justfile'
 
 env:
-  IMAGE_REGISTRY: "ghcr.io/${{ github.repository_owner }}"
-  IMAGE_NAME: "yourimagename"
+  IMAGE_REGISTRY: "ghcr.io/${{ github.repository }}"
   DEFAULT_TAG: "latest"
-  BUILD_ARCH: [ # You can control which architectures you build for by setting this variable
-    #arm64, 
-    amd64,
-    ]
-  S3_PROVIDER: "yours3provider" # Must be one of the following values:  
-  S3_BUCKET_NAME: "yourbucketname"
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.ref || github.run_id }}
@@ -35,19 +34,21 @@ concurrency:
 jobs:
   build:
     name: Build ISOs
-    runs-on: ${{ matrix.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    runs-on: ${{ inputs.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
     strategy:
       fail-fast: false
-      matrix:
-        platform: $BUILD_ARCH
     permissions:
       contents: read
       packages: read
       id-token: write
 
     steps:
+      - name: lower case the image registry in case of any capitalization
+        run: |
+          echo "IMAGE_REGISTRY=${IMAGE_REGISTRY,,}" >> ${GITHUB_ENV}
+      
       - name: Install dependencies
-        if: matrix.platform == 'arm64'
+        if: inputs.platform == 'arm64'
         run: |
           set -x
           sudo apt update -y
@@ -55,7 +56,7 @@ jobs:
             podman
 
       - name: Maximize build space
-        if: matrix.platform != 'arm64'
+        if: inputs.platform != 'arm64'
         uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
         with:
           remove-codeql: true
@@ -73,14 +74,14 @@ jobs:
           bootc-image-builder-image: ghcr.io/centos-workstation/bootc-image-builder:latest
           use-librepo: true
           config-file: ./iso.toml
-          image: ${{ env.IMAGE_REGISTRY }}/${{ env.IMAGE_NAME }}:${{ env.DEFAULT_TAG }}
+          image: ${{ env.IMAGE_REGISTRY }}:${{ env.DEFAULT_TAG }}
 
       - name: Upload to S3
         if: inputs.upload-to-s3 == true && github.event_name != 'pull_request'
         shell: bash
         env:
           RCLONE_CONFIG_S3_TYPE: s3
-          RCLONE_CONFIG_S3_PROVIDER: ${{ env.S3_PROVIDER }}
+          RCLONE_CONFIG_S3_PROVIDER: ${{ secrets.S3_PROVIDER }}
           RCLONE_CONFIG_S3_ACCESS_KEY_ID: ${{ secrets.S3_ACCESS_KEY_ID }}
           RCLONE_CONFIG_S3_SECRET_ACCESS_KEY: ${{ secrets.S3_SECRET_ACCESS_KEY }}
           RCLONE_CONFIG_S3_REGION: ${{ secrets.S3_REGION }}
@@ -89,4 +90,4 @@ jobs:
         run: |
           sudo apt-get update
           sudo apt-get install -y rclone
-          rclone copy $SOURCE_DIR S3:${{ env.S3_BUCKET_NAME }}
+          rclone copy $SOURCE_DIR S3:${{ secrets.S3_BUCKET_NAME }}

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ This file defines the operations used to customize the selected image. It contai
 
 This template provides an out of the box workflow for getting an ISO image for your custom OCI image which can be used to directly install onto your machines.
 
-Due to the large file size of ISOs and the limits of [GitHub's artifacts](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas) this template provides a way to upload the ISO that is generated from the workflow to a S3 bucket. To upload to S3 we use a tool called [rclone](https://rclone.org/) which is able to use [many S3 providers](https://rclone.org/s3/). For more details on how to configure this see the details [below](#build-isoyml).
+This template provides a way to upload the ISO that is generated from the workflow to a S3 bucket or it will be available as an artifact from the job. To upload to S3 we use a tool called [rclone](https://rclone.org/) which is able to use [many S3 providers](https://rclone.org/s3/). For more details on how to configure this see the details [below](#build-isoyml).
 
 ## Workflows
 
@@ -63,7 +63,7 @@ This workflow creates an ISO from your OCI image by utilizing the [bootc-image-b
 
 - Modify `iso.toml` to point to your custom image before generating an ISO.
 - If you changed your image name from the default in `build.yml` then in the `build-iso.yml` file edit the `IMAGE_REGISTRY` and `DEFAULT_TAG` environment variables with the correct values. If you did not make changes, skip this step.
-- Finally, we will need to add our S3 configuration to our Action secrets. This can be found by going to your repository settings, under Secrets and Variables -> Actions. You will need to add the following
+- Finally, if you want to upload your ISOs to S3 then you will need to add your S3 configuration to the repository's Action secrets. This can be found by going to your repository settings, under `Secrets and Variables` -> `Actions`. You will need to add the following
   - `S3_PROVIDER` - Must match one of the values from the [supported list](https://rclone.org/s3/)
   - `S3_BUCKET_NAME` - Your unique bucket name
   - `S3_ACCESS_KEY_ID` - It is recommended that you make a separate key just for this workflow
@@ -93,7 +93,7 @@ This provides users a method of verifying the image.
 
 3. Add the private key to GitHub
 
-    - This can also be done manually. Go to your repository settings, under Secrets and Variables -> Actions
+    - This can also be done manually. Go to your repository settings, under `Secrets and Variables` -> `Actions`
     ![image](https://user-images.githubusercontent.com/1264109/216735595-0ecf1b66-b9ee-439e-87d7-c8cc43c2110a.png)
     Add a new secret and name it `SIGNING_SECRET`, then paste the contents of `cosign.key` into the secret and save it. Make sure it's the .key file and not the .pub file. Once done, it should look like this:
     ![image](https://user-images.githubusercontent.com/1264109/216735690-2d19271f-cee2-45ac-a039-23e6a4c16b34.png)

--- a/README.md
+++ b/README.md
@@ -47,15 +47,29 @@ This file defines the operations used to customize the selected image. It contai
 
 ## Building an ISO
 
-Modify `iso.toml` to point to your custom image before generating an ISO.
+This template provides an out of the box workflow for getting an ISO image for your custom OCI image which can be used to directly install onto your machines.
 
-- (Steps in progress)
+Due to the large file size of ISOs and the limits of [GitHub's artifacts](https://docs.github.com/en/repositories/releasing-projects-on-github/about-releases#storage-and-bandwidth-quotas) this template provides a way to upload the ISO that is generated from the workflow to a S3 bucket. To upload to S3 we use a tool called [rclone](https://rclone.org/) which is able to use [many S3 providers](https://rclone.org/s3/). For more details on how to configure this see the details [below](#build-isoyml).
 
 ## Workflows
 
 ### build.yml
 
 This workflow creates your custom OCI image and publishes it to the Github Container Registry (GHCR). By default, the image name will match the Github repository name.
+
+### build-iso.yml
+
+This workflow creates an ISO from your OCI image by utilizing the [bootc-image-builder](https://osbuild.org/docs/bootc/) to generate an ISO. In order to use this workflow you must complete the following steps:
+
+- Modify `iso.toml` to point to your custom image before generating an ISO.
+- If you changed your image name from the default in `build.yml` then in the `build-iso.yml` file edit the `IMAGE_REGISTRY` and `DEFAULT_TAG` environment variables with the correct values. If you did not make changes, skip this step.
+- Finally, we will need to add our S3 configuration to our Action secrets. This can be found by going to your repository settings, under Secrets and Variables -> Actions. You will need to add the following
+  - `S3_PROVIDER` - Must match one of the values from the [supported list](https://rclone.org/s3/)
+  - `S3_BUCKET_NAME` - Your unique bucket name
+  - `S3_ACCESS_KEY_ID` - It is recommended that you make a separate key just for this workflow
+  - `S3_SECRET_ACCESS_KEY`
+  - `S3_REGION` - The region your bucket lives in. If you do not know then set this value to `auto`.
+  - `S3_ENDPOINT` - This value will be specific to the bucket as well.
 
 #### Container Signing
 

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ This workflow creates an ISO from your OCI image by utilizing the [bootc-image-b
   - `S3_PROVIDER` - Must match one of the values from the [supported list](https://rclone.org/s3/)
   - `S3_BUCKET_NAME` - Your unique bucket name
   - `S3_ACCESS_KEY_ID` - It is recommended that you make a separate key just for this workflow
-  - `S3_SECRET_ACCESS_KEY`
+  - `S3_SECRET_ACCESS_KEY` - See above.
   - `S3_REGION` - The region your bucket lives in. If you do not know then set this value to `auto`.
   - `S3_ENDPOINT` - This value will be specific to the bucket as well.
 

--- a/README.md
+++ b/README.md
@@ -71,6 +71,8 @@ This workflow creates an ISO from your OCI image by utilizing the [bootc-image-b
   - `S3_REGION` - The region your bucket lives in. If you do not know then set this value to `auto`.
   - `S3_ENDPOINT` - This value will be specific to the bucket as well.
 
+Once the workflow is done, you'll find it either in your S3 bucket or as part of the summary under `Artifacts` after the workflow is completed.
+
 #### Container Signing
 
 Container signing is important for end-user security and is enabled on all Universal Blue images. It is recommended you set this up, and by default the image builds *will fail* if you don't.

--- a/iso.toml
+++ b/iso.toml
@@ -1,7 +1,7 @@
 [customizations.installer.kickstart]
 contents = """
 %post
-bootc switch --mutate-in-place --transport registry ghcr.io/yourname/yourusername:latest
+bootc switch --mutate-in-place --transport registry ghcr.io/yourrepo/yourimage:latest
 %end
 """
 


### PR DESCRIPTION
This PR adds a new optional workflow to the image template that allows a user to create an ISO using the `bootc-image-builder` utility. It supports either `amd64` and `arm64` architectures however not both in the same workflow due to limitations around the `choice` input for actions.

After some discussion in the discord about the best way to accomplish this feature we decided it was best to just start with what Bluefin is doing and upload to S3 rather than try to always come in under the 2GB limit that Actions has. In my testing a barebones ISO comes in at 1.9GB, so adding a couple things can easily push this over the limit. In order to try to make the DX/UX as smooth as possible I decided to 1) make the workflow compatible with any S3 provider rather than just R2 and 2) keep all the S3 config options together as secrets rather than splitting them up between environment variables and secrets. I also like this as it reuses the logic and steps for `SIGNING_SECRETS`.

I did test this successfully against R2 and B2 and rclone worked great:

![Screenshot From 2025-03-12 22-16-22](https://github.com/user-attachments/assets/1032e8ce-8f24-43a7-9627-09b6555c36d3)

I'm open to any feedback about wording or variables names, don't feel nitpicky. Do you guys think this is a useful feature for people wanting a custom image?

