### PR TITLE
feat: build in tempdir and move files on success

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 cosign.key
 _build_*
 output
+_build-*/**

--- a/Justfile
+++ b/Justfile
@@ -210,8 +210,9 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
       ${args} \
       "${target_image}:${tag}"
 
-    rm -rf output
-    sudo mv -f $BUILDTMP output
+    mkdir -p output
+    sudo mv -f $BUILDTMP/* output/
+    sudo rmdir $BUILDTMP
     sudo chown -R $USER:$USER output/
 
 # Podman builds the image from the Containerfile and creates a bootable image

--- a/Justfile
+++ b/Justfile
@@ -45,6 +45,7 @@ clean:
     rm -f previous.manifest.json
     rm -f changelog.md
     rm -f output.env
+    rm -f output/
 
 # Sudo Clean Repo
 [group('Utility')]

--- a/Justfile
+++ b/Justfile
@@ -211,8 +211,9 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
       "${target_image}:${tag}"
 
     mkdir -p output
-    sudo mv -f $BUILDTMP "output/${type}"
-    sudo chown -R $USER:$USER "output/${type}"
+    sudo mv -f $BUILDTMP/* output/
+    sudo rmdir $BUILDTMP
+    sudo chown -R $USER:$USER output/
 
 # Podman builds the image from the Containerfile and creates a bootable image
 # Parameters:

--- a/Justfile
+++ b/Justfile
@@ -193,7 +193,7 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
         args+=" --local"
     fi
 
-    TEMPDIR=$(mktemp -d)
+    BUILDTMP=$(mktemp -p "${PWD}" -d -t _build-bib.XXXXXXXXXX)
 
     sudo podman run \
       --rm \
@@ -203,14 +203,14 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
       --net=host \
       --security-opt label=type:unconfined_t \
       -v $(pwd)/${config}:/config.toml:ro \
-      -v $TEMPDIR:/output \
+      -v $BUILDTMP:/output \
       -v /var/lib/containers/storage:/var/lib/containers/storage \
       "${bib_image}" \
       ${args} \
       "${target_image}:${tag}"
 
     mkdir -p output
-    sudo mv -f $TEMPDIR "output/${type}"
+    sudo mv -f $BUILDTMP "output/${type}"
     sudo chown -R $USER:$USER "output/${type}"
 
 # Podman builds the image from the Containerfile and creates a bootable image

--- a/Justfile
+++ b/Justfile
@@ -210,9 +210,8 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
       ${args} \
       "${target_image}:${tag}"
 
-    mkdir -p output
-    sudo mv -f $BUILDTMP/* output/
-    sudo rmdir $BUILDTMP
+    rm -rf output
+    sudo mv -f $BUILDTMP output
     sudo chown -R $USER:$USER output/
 
 # Podman builds the image from the Containerfile and creates a bootable image


### PR DESCRIPTION
Before it would delete your outputs before starting the build. That means miss-typing the command for example could lead to losing data. This also creates separate folders for each type to avoid collision.