### PR TITLE
ci: make sure renovate uses best-practices preset

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "config:best-practices"
   ]
 }


### PR DESCRIPTION
Even if they say that its best for people that want the best practices on the docs, we should make people using this template have this safer thing by default

https://docs.renovatebot.com/presets-config/#configbest-practices