### PR TITLE
ci: use the same renovate config as bluefin-lts

### DIFF
--- a/.github/renovate.json5
+++ b/.github/renovate.json5
@@ -1,6 +1,21 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:best-practices"
+    "config:best-practices",
+  ],
+
+  "rebaseWhen": "never",
+
+  "packageRules": [
+    {
+      "automerge": true,
+      "matchUpdateTypes": ["pin", "pinDigest"]
+    },
+    {
+      "enabled": false,
+      "matchUpdateTypes": ["digest", "pinDigest", "pin"],
+      "matchDepTypes": ["container"],
+      "matchFileNames": [".github/workflows/**.yaml", ".github/workflows/**.yml"],
+    },
   ]
 }

--- a/Containerfile
+++ b/Containerfile
@@ -1,4 +1,4 @@
-FROM ghcr.io/ublue-os/bazzite:stable@sha256:b0655252e3d7b53d7c3b4469e4d84635341b991c22a11fb0dc85dba802f9cb27
+FROM ghcr.io/ublue-os/bazzite:stable
 
 ## Other possible base images include:
 # FROM ghcr.io/ublue-os/bazzite:latest


### PR DESCRIPTION
This one makes it so we (and people that use this template) dont need to manually bump the docker images all the time, like we ran into with [bluefin LTS](https://github.com/ublue-os/bluefin-lts/pull/398#issuecomment-2726873005)
