### PR TITLE
fix: Add rootfs argument to _build-bib

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -189,6 +189,7 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
 
     args="--type ${type} "
     args+="--use-librepo=True"
+    args+="--rootfs=btrfs"
 
     if [[ $target_image == localhost/* ]]; then
         args+=" --local"

--- a/Justfile
+++ b/Justfile
@@ -188,7 +188,7 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
     set -euo pipefail
 
     args="--type ${type} "
-    args+="--use-librepo=True"
+    args+="--use-librepo=True "
     args+="--rootfs=btrfs"
 
     if [[ $target_image == localhost/* ]]; then


### PR DESCRIPTION
Due to the lack of a `--rootfs` build argument in the Justfile by default, building virtual machines keeps failing because of the aforementioned issue, so I decided to open up a PR to add this argument to avoid future headaches for future custom image builders.

I have used Btrfs as the default option due to it being the default filesystem choice on Fedora and the Universal Blue images.