### PR TITLE
fix: fix weird behavior in just run-vm

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -289,9 +289,8 @@ _run-vm $target_image $tag $type $config:
     run_args+=(docker.io/qemux/qemu-docker)
 
     # Run the VM and open the browser to connect
-    podman run "${run_args[@]}" &
-    xdg-open http://localhost:${port}
-    fg "%podman"
+    (sleep 30 && xdg-open http://localhost:"$port") &
+    podman run "${run_args[@]}"
 
 # Run a virtual machine from a QCOW2 image
 [group('Run Virtal Machine')]


### PR DESCRIPTION
This PR fixes weird behavior with the `just run-vm` command that causes the output to print out in a regular shell outside the command, making operation via the terminal difficult in certain situations, and removes an unnecessary `fg` command due to the lack of job-control capability.

It also (in my experience) helps fix an issue about Intel GPU drivers taking an unusually long time to install in the QEMU Docker image. 