### PR TITLE
fix(justfile): `just lint` and `just format` pass when `shellcheck` and `shfmt` do not exist

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -339,10 +339,10 @@ lint:
 format:
      #!/usr/bin/env bash
     set -eoux pipefail
-    # Check if shellcheck is installed
+    # Check if shfmt is installed
     if ! command -v shfmt &> /dev/null; then
         echo "shellcheck could not be found. Please install it."
         exit 1
     fi
-    # Run shellcheck on all Bash scripts
+    # Run shfmt on all Bash scripts
     /usr/bin/find . -iname "*.sh" -type f -exec shfmt --write "{}" ';'


### PR DESCRIPTION
Fixes #104