### PR TITLE
fix(just): fix syntax error

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -337,7 +337,7 @@ lint:
 
 # Runs shfmt on all Bash scripts
 format:
-     #!/usr/bin/env bash
+    #!/usr/bin/env bash
     set -eoux pipefail
     # Check if shfmt is installed
     if ! command -v shfmt &> /dev/null; then


### PR DESCRIPTION
introduced in 083532b8ff
```
error: Recipe line has inconsistent leading whitespace. Recipe started with `␠␠␠␠␠` but found line with `␠␠␠␠` ——▶ Justfile:341:1
│
341 │     set -eoux pipefail
│ ^^^^
```