### PR TITLE
fix: Kickstart post installation script not executing

### DIFF
--- a/disk_config/iso.toml
+++ b/disk_config/iso.toml
@@ -7,7 +7,8 @@ bootc switch --mutate-in-place --transport registry ghcr.io/ublue-os/image-templ
 
 [customizations.installer.modules]
 enable = [
-  "org.fedoraproject.Anaconda.Modules.Storage"
+  "org.fedoraproject.Anaconda.Modules.Storage",
+  "org.fedoraproject.Anaconda.Modules.Runtime"
 ]
 disable = [
   "org.fedoraproject.Anaconda.Modules.Network",


### PR DESCRIPTION
The current default configuration prevent bootc from executing post installation scripts. Causing bootc not mutatating the image from the iso to the registry one.

This PR apply the fix from this comment from glen-gibson: https://github.com/osbuild/bootc-image-builder/issues/968#issuecomment-3086099219