### PR TITLE
feat(ci): add fallback condition for btrfs bind mount

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,15 @@ jobs:
       #     remove-codeql: true
 
       - name: Mount BTRFS for podman storage
-        uses: ublue-os/container-storage-action@main
+        id: container-storage-action
+        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
+
+        # Fallback to the remove-unwanted-software-action if github doesn't allocate enough space
+        # See: https://github.com/ublue-os/container-storage-action/pull/11
+        continue-on-error: true 
+        with:
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
 
       - name: Get current date
         id: date


### PR DESCRIPTION
Random failures of this action may occur when many runners are started at the same time and github can't allocate enough disk space.
- adds a fallback to the old action if that is the case.

- logic has been used in production in Aurora and Bluefin since 2 months

See: https://github.com/ublue-os/container-storage-action/pull/11