### PR TITLE
feat: enable packages to install in /opt/

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -17,11 +17,14 @@ FROM ghcr.io/ublue-os/bazzite:stable
 ### MODIFICATIONS
 ## make modifications desired in your image and install packages by modifying the build.sh script
 ## the following RUN directive does all the things required to run "build.sh" as recommended.
+## "rm /opt && mkdir /opt" deletes the symlink at /opt/ and creates the /opt/ directory to enable packages to be installed in it, e.g., google-chrome.
 
 RUN --mount=type=bind,from=ctx,source=/,target=/ctx \
     --mount=type=cache,dst=/var/cache \
     --mount=type=cache,dst=/var/log \
     --mount=type=tmpfs,dst=/tmp \
+    rm /opt && \
+    mkdir /opt && \
     /ctx/build.sh
     
 ### LINTING


### PR DESCRIPTION
Currently packages such as chromium forks and winboat cannot be built on custom images because /opt/ is a symlink to /var/opt/. /var/opt is on the persistent side of atomic fedora. However on atomic fedora, nothing on the fedora base images use /opt/. My assumption is their assumption was to symlink /opt/ to /var/opt/ as best practice because it was only a vestigial appendage for atomic fedora. Ublue simply inherits that symlink out of inertia. But custom images need to use that vestigial appendage to install packages. Per FHS /opt/ should only be used for static installation files of third party applications and /var/opt/ is used for those applications' dynamic runtimes. After being built, nothing should be written to /opt/ on atomic fedora or ublue regardless of it being a directory or a symlink. The solution for custom ublue images, therefore, should be this pr that deletes the /opt/ symlink and creates the /opt/ directory. Other solutions are firstly unnecessary and secondly impractical. 

credit goes to @fpfcmsr for finding this solution