### PR TITLE
add akmods section

### DIFF
--- a/README.md
+++ b/README.md
@@ -249,6 +249,10 @@ Runs shell check on all Bash scripts.
 
 Runs shfmt on all Bash scripts.
 
+## Additional resources
+
+For additional driver support, ublue maintains a set of scripts and container images available at [ublue-akmod](https://github.com/ublue-os/image-template). These images include the necessary scripts to install multiple kernel drivers within the container (Nvidia, OpenRazer, Framework...). The documentation provides guidance on how to properly integrate these drivers into your container image.
+
 ## Community Examples
 
 These are images derived from this template (or similar enough to this template). Reference them when building your image!


### PR DESCRIPTION
I suggest adding a section for supplementary resources. It should contain a brief explanation (to avoid overly complex tutorials and documentation), as well as a link to your akmods image repository. This section will then allow you to add any important resources not mentioned in the guide's general recommendations.