### PR TITLE
chore: remove btrfs-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,21 +46,9 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # You only use this action if the container-storage-action proves to be unreliable, you don't need to enable both
       # This is optional, but if you see that your builds are way too big for the runners, you can enable this by uncommenting the following lines:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6
-
-      - name: Mount BTRFS for podman storage
-        id: container-storage-action
-        uses: ublue-os/container-storage-action@911baca08baf30c8654933e9e9723cb399892140
-
-        # Fallback to the remove-unwanted-software-action if github doesn't allocate enough space
-        # See: https://github.com/ublue-os/container-storage-action/pull/11
-        continue-on-error: true 
-        with:
-          target-dir: /var/lib/containers
-          mount-opts: compress-force=zstd:2
 
       - name: Get current date
         id: date


### PR DESCRIPTION
Github removed /mnt from their runners and /dev/root is now 145G, before it was 72G so the btrfs action was needed. This action is broken now and always used the fallback path and has no purpose anymore.

<img width="1198" height="586" alt="image" src="https://github.com/user-attachments/assets/d7f391f2-b790-4200-b08c-4bc7819866e7" />
