### PR TITLE
chore(ci): remove remove-unwanted-software-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -46,10 +46,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
 
-      # This is optional, but if you see that your builds are way too big for the runners, you can enable this by uncommenting the following lines:
-      - name: Maximize build space
-        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6
-
       - name: Get current date
         id: date
         run: |


### PR DESCRIPTION
This shouldn't be needed anymore as GitHub runners now have 89G free that are accessible without any hacks like in the action mentioned below.

Related: https://github.com/ublue-os/container-storage-action/issues/14