### PR TITLE
Use built-in sudoif instead of sudo

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -168,7 +168,7 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
 
     BUILDTMP=$(mktemp -p "${PWD}" -d -t _build-bib.XXXXXXXXXX)
 
-    sudo podman run \
+    just sudoif podman run \
       --rm \
       -it \
       --privileged \
@@ -183,9 +183,9 @@ _build-bib $target_image $tag $type $config: (_rootful_load_image target_image t
       "${target_image}:${tag}"
 
     mkdir -p output
-    sudo mv -f $BUILDTMP/* output/
-    sudo rmdir $BUILDTMP
-    sudo chown -R $USER:$USER output/
+    just sudoif mv -f $BUILDTMP/* output/
+    just sudoif rmdir $BUILDTMP
+    just sudoif chown -R $USER:$USER output/
 
 # Podman builds the image from the Containerfile and creates a bootable image
 # Parameters:


### PR DESCRIPTION
Use ```just sudoif``` when building the iso image on hosts without ```sudo``` installed but running as root.