### PR TITLE
added -r flag to rm command for output dir

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -42,7 +42,7 @@ clean:
     rm -f previous.manifest.json
     rm -f changelog.md
     rm -f output.env
-    rm -f output/
+    rm -rf output/
 
 # Sudo Clean Repo
 [group('Utility')]


### PR DESCRIPTION
The -r flag was missing from the 'rm' command causing it to fail.