### PR TITLE
feat(chunkah): use oci-dir output and config file

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ cosign.key
 _build_*
 output
 _build-*/**
+*_chunkah_*

--- a/Justfile
+++ b/Justfile
@@ -149,6 +149,7 @@ rechunk $target_image=image_name $tag=default_tag:
       --mount=type=image,src="${target_image}:${tag}",target=/chunkah \
       -v "${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro,Z" \
       -v "${CHUNKAH_OUTPUT_DIR}:/run/out:Z" \
+      -e SOURCE_DATE_EPOCH=0 \
       quay.io/coreos/chunkah:latest \
       build \
       --verbose \

--- a/Justfile
+++ b/Justfile
@@ -138,8 +138,9 @@ rechunk $target_image=image_name $tag=default_tag:
     # base image is also using chunkah
     CHUNKAH_CONFIG_FILE="$(mktemp)"
 
-    # You may omit --tmpdir here when you are confident /tmp has enough space
-    CHUNKAH_OUTPUT_DIR="$(mktemp -d --tmpdir="${PWD}")"
+    # You may omit the current directory here if you are confident that you
+    # won't run out of space on /tmp for your image
+    CHUNKAH_OUTPUT_DIR="$(mktemp -d ./"${target_image}"_chunkah_XXXXXX)"
 
     trap 'rm -f "${CHUNKAH_CONFIG_FILE}"; rm -rf "${CHUNKAH_OUTPUT_DIR}"' EXIT
     podman inspect "${target_image}:${tag}" > "${CHUNKAH_CONFIG_FILE}"

--- a/Justfile
+++ b/Justfile
@@ -133,18 +133,33 @@ rechunk $target_image=image_name $tag=default_tag:
     set -xeuo pipefail
 
     # TODO: pin chunkah image to hash once mature enough
-    # You may run into space issues on github runenrs as we are making a
-    # complete copy of the image
-    export CHUNKAH_CONFIG_STR=$(podman inspect "${target_image}")
-    podman run --rm --mount=type=image,src="${target_image}",target=/chunkah \
-    -e CHUNKAH_CONFIG_STR quay.io/coreos/chunkah:latest \
-    build \
-    --verbose \
-    --compressed \
-    --max-layers 128 \
-    --prune /sysroot/ \
-    --label ostree.commit- --label ostree.final-diffid- \
-    --tag "${target_image}:${tag}" | podman load
+    # You may run into space issues on github runners as we are making a
+    # complete copy of the image, which likely has no shared layers, unless your
+    # base image is also using chunkah
+    CHUNKAH_CONFIG_FILE="$(mktemp)"
+
+    # You may omit --tmpdir here when you are confident /tmp has enough space
+    CHUNKAH_OUTPUT_DIR="$(mktemp -d --tmpdir="${PWD}")"
+
+    trap 'rm -f "${CHUNKAH_CONFIG_FILE}"; rm -rf "${CHUNKAH_OUTPUT_DIR}"' EXIT
+    podman inspect "${target_image}:${tag}" > "${CHUNKAH_CONFIG_FILE}"
+
+    podman run --rm \
+      --mount=type=image,src="${target_image}:${tag}",target=/chunkah \
+      -v "${CHUNKAH_CONFIG_FILE}:/chunkah-config.json:ro,Z" \
+      -v "${CHUNKAH_OUTPUT_DIR}:/run/out:Z" \
+      quay.io/coreos/chunkah:latest \
+      build \
+      --verbose \
+      --compressed \
+      --max-layers 128 \
+      --prune /sysroot/ \
+      --label ostree.commit- --label ostree.final-diffid- \
+      --config /chunkah-config.json \
+      --output oci:/run/out/chunked
+
+    CHUNKED_IMAGE="$(podman pull "oci:${CHUNKAH_OUTPUT_DIR}/chunked")"
+    podman tag "${CHUNKED_IMAGE}" "${target_image}:${tag}"
 
 # Split the image for smaller updates (Classical)!
 ostree-rechunk $target_image=image_name $tag=default_tag:


### PR DESCRIPTION
hhd-rechunk writes a giant label with all the packages which exceeds the
size limit of what environment variables can hold. So base images still
using that (bluefin) will break otherwise. So we are using a config file
instead. Fixes: [1]. This also happens to make the output a lot less
noisy.

Since the initial implementation of chunkah here, it now supports
writing to an oci directory, which happens to be faster[2].

I chose to write the output of chunkah to the current directory instead
of /tmp because on gh runners we have 8G space there and we don't know
for certain what users will use /tmp during their build for and how big
the base image is. For example bazzite takes up 4.5GB (compressed). To
me this is the more conservative option.

I currently do not want to introduce the complexity of altering behavior
based on if it's running inside github. Where we could delete the base
image and unrechunked built image before we pull in the rechunked one.

I forgot to add the tag variable in 7f9dd326ec8.

[1]: https://github.com/ublue-os/image-template/issues/236
[2]: https://github.com/coreos/chunkah#output-options

Co-authored-by: Benjamin Blasco <bblasco@redhat.com>
