### PR TITLE
chore: update to cosign v3 and don't break things

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -145,9 +145,9 @@ jobs:
       - name: Install Cosign
         uses: sigstore/cosign-installer@6f9f17788090df1f26f669e9d70d6ae9567deba6 # v4.1.2
         if: github.event_name != 'pull_request' && github.ref == format('refs/heads/{0}', github.event.repository.default_branch)
-        # https://github.com/containers/container-libs/issues/388
         with:
-          cosign-release: 'v2.6.3'
+          # be careful when upgrading major versions
+          cosign-release: 'v3.1.2'
 
       - name: Sign container image
         id: sign-image
@@ -157,5 +157,8 @@ jobs:
           COSIGN_PRIVATE_KEY: ${{ secrets.SIGNING_SECRET }}
           DIGEST: ${{ steps.push-image.outputs.digest }}
         run: |
-          cosign sign -y --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
+          # https://github.com/containers/container-libs/issues/388
+          # https://github.com/coreos/rpm-ostree/issues/5509
+          # use old bundle format, so we can use newer cosign 3.X.X instead of 2.X.X
+          cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
 


### PR DESCRIPTION
This is the way to workaround the upstream issues I linked below.

We need `--use-signing-config=false` or else we are getting the following erorr:

```
Error: must provide --new-bundle-format or --bundle where applicable
with --signing-config or --use-signing-config error during command
```

supersedes: https://github.com/ublue-os/image-template/pull/242 and https://github.com/ublue-os/image-template/pull/241

This exact combination of versions + args has been used in Aurora for a while. I tested this in my own custom image and setting up a containers policy for that and podman/bootc still pulls it