### PR TITLE
feat(ci): add container-storage-action

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,6 +38,13 @@ jobs:
       - name: Maximize build space
         uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6
 
+      - name: Mount sporadic /mnt as btrfs loopback for containers storage
+        uses: ublue-os/container-storage-action@dc1f4c8f17b672069e921f001132f7cf98a423a6
+        with:
+          target-dir: /var/lib/containers
+          mount-opts: compress-force=zstd:2
+          loopback-free: 1
+
       - name: Install just
         uses: extractions/setup-just@53165ef7e734c5c07cb06b3c8e7b647c5aa16db3 #v4.0.0
 
@@ -162,3 +169,10 @@ jobs:
           # use old bundle format, so we can use newer cosign 3.X.X instead of 2.X.X
           cosign sign -y --new-bundle-format=false --use-signing-config=false --key env://COSIGN_PRIVATE_KEY ${IMAGE_REGISTRY}/${IMAGE_NAME}@${DIGEST}
 
+      - name: Disk usage summary
+        if: always()
+        run: |
+          echo "### Disk usage" >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"
+          df -h >> "$GITHUB_STEP_SUMMARY"
+          echo '```' >> "$GITHUB_STEP_SUMMARY"


### PR DESCRIPTION
Since 7f9dd326e we are now rechunking by default which needs more disk space.

Free space on Github runners varies heavily. This is why the build should most of the time succeed.

I did some testing a while ago and looked at the storage configuration of github across 84 runs. Take these numbers with a grain of salt, this will absolutely change in the future.

The most likely configuration (at the time I was testing this) with roughly 90% of the time had the biggest configuration with a single 145G disk and gets us somewhere in between 70-110G free. This is good enough for our purposes. We wouldn't have to do anything here.

There are also configurations with a 72G disk and among those we have 20G of free space. 70% of those runners had another drive at /mnt mounted which is completely not used at all by default. This additional drive is 66G big and we can compensate a little bit for the space we don't have otherwise by mounting this unused drive to /var/lib/containers in this case. During the build we predominantly need space there so it makes sense to do that. Even in this configuration we need the remove-unwanted-software action because we could still end up with a 20G free on /. This matters because in the case of chunkah because we are writing the compressed oci directory (roughly 4.5GB for bazzite) there and intermediary image pulls/build cache is written to /var/tmp.

The remaining 30% of the 72G disk pool does not have this additional drive so the only thing we can do is rely on remove-unwanted-software to free up enough space. This either gets us (somewhat evenly distributed) either 37G or 47G free.

This doesn't make it impossible to run out of disk space, it just makes it less likely to happen.