### PR TITLE
feat: make rpm-ostree use oci-dir + rootless CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -70,7 +70,7 @@ jobs:
       - name: Build Image
         id: build-image
         run: |
-          sudo -E $(command -v just) build \
+          just build \
             ${IMAGE_NAME} \
             ${DEFAULT_TAG}
 
@@ -78,7 +78,7 @@ jobs:
       - name: Rechunk with rpm-ostree
         id: rechunk
         run: |
-          sudo -E $(command -v just) ostree-rechunk \
+          just ostree-rechunk \
             ${IMAGE_NAME} \
             ${DEFAULT_TAG}
 
@@ -88,7 +88,7 @@ jobs:
       #- name: Rechunk with Chunkah
       #  id: rechunk
       #  run: |
-      #    sudo -E $(command -v just) rechunk \
+      #    just rechunk \
       #      ${IMAGE_NAME} \
       #      ${DEFAULT_TAG}
 
@@ -108,7 +108,7 @@ jobs:
         env:
           ALIAS_TAGS: ${{ steps.gen-build-tags.outputs.alias_tags }}
         run: |
-          sudo -E $(command -v just) tag-images \
+          just tag-images \
             "${IMAGE_NAME}" \
             "${DEFAULT_TAG}" \
             "${ALIAS_TAGS}"
@@ -131,7 +131,7 @@ jobs:
         run: |
           set -euox pipefail
           for tag in ${ALIAS_TAGS}; do
-            sudo -E podman push --digestfile=/tmp/digestfile ${IMAGE_NAME}:${tag} ${IMAGE_REGISTRY}/${IMAGE_NAME}:${tag}
+            podman push --digestfile=/tmp/digestfile ${IMAGE_NAME}:${tag} ${IMAGE_REGISTRY}/${IMAGE_NAME}:${tag}
           done
 
           digest=$(< /tmp/digestfile)

--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ _build_*
 output
 _build-*/**
 *_chunkah_*
+*_rpm-ostree_*

--- a/Justfile
+++ b/Justfile
@@ -171,17 +171,9 @@ ostree-rechunk $target_image=image_name $tag=default_tag:
     # Use the already-built local image to avoid pulling from a remote registry
     RPM_OSTREE_CHUNKER_IMAGE="localhost/${target_image}:${tag}"
 
-    trap 'rm -rf "${RPM_OSTREE_OUTPUT_DIR}"' EXIT
-
     RPM_OSTREE_OUTPUT_DIR="$(mktemp -d ./"${target_image}"_rpm-ostree_XXXXXX)"
-    SUBDIR="${target_image}"
-    RPM_OSTREE_OUTPUT_SUBDIR="${RPM_OSTREE_OUTPUT_DIR}/${SUBDIR}"
 
-    # https://github.com/coreos/rpm-ostree/blob/d97c7a2b3ecd877b7e1ccba7df2d824889029514/tests/compose-image.sh#L100-L109
-    # or else we get `error: failed to invoke method OpenImageOptional: open /run/out/image-template/index.json: no such file or directory`
-    mkdir -p "${RPM_OSTREE_OUTPUT_SUBDIR}"
-    echo '{"imageLayoutVersion": "1.0.0"}' > "${RPM_OSTREE_OUTPUT_SUBDIR}/oci-layout"
-    echo '{"schemaVersion": 2, "manifests": []}' > "${RPM_OSTREE_OUTPUT_SUBDIR}/index.json"
+    trap 'rm -rf "${RPM_OSTREE_OUTPUT_DIR}"' EXIT
 
     podman run --rm \
       --pull=never \
@@ -195,9 +187,9 @@ ostree-rechunk $target_image=image_name $tag=default_tag:
       --format-version=2 \
       --bootc \
       --rootfs /rpm-ostree \
-      --output oci:/run/out/"${SUBDIR}":${tag}
+      --output oci-archive:/run/out/"${target_image}.oci"
 
-    CHUNKED_IMAGE="$(podman pull oci:"${RPM_OSTREE_OUTPUT_SUBDIR}")"
+    CHUNKED_IMAGE="$(podman pull oci-archive:"${RPM_OSTREE_OUTPUT_DIR}/${target_image}.oci")"
     podman tag "${CHUNKED_IMAGE}" "${target_image}:${tag}"
 
 # Generate Default Tag

--- a/Justfile
+++ b/Justfile
@@ -168,28 +168,37 @@ ostree-rechunk $target_image=image_name $tag=default_tag:
 
     set -xeuo pipefail
 
-    # TODO: This is the only blocker for rootless CI
-    # https://github.com/coreos/rpm-ostree/issues/5346
-    if [[ ! "${UID}" -eq "0" ]]; then
-      echo "This needs to run as root."
-      exit 1
-    fi
-
     # Use the already-built local image to avoid pulling from a remote registry
     RPM_OSTREE_CHUNKER_IMAGE="localhost/${target_image}:${tag}"
 
+    trap 'rm -rf "${RPM_OSTREE_OUTPUT_DIR}"' EXIT
+
+    RPM_OSTREE_OUTPUT_DIR="$(mktemp -d ./"${target_image}"_rpm-ostree_XXXXXX)"
+    SUBDIR="${target_image}"
+    RPM_OSTREE_OUTPUT_SUBDIR="${RPM_OSTREE_OUTPUT_DIR}/${SUBDIR}"
+
+    # https://github.com/coreos/rpm-ostree/blob/d97c7a2b3ecd877b7e1ccba7df2d824889029514/tests/compose-image.sh#L100-L109
+    # or else we get `error: failed to invoke method OpenImageOptional: open /run/out/image-template/index.json: no such file or directory`
+    mkdir -p "${RPM_OSTREE_OUTPUT_SUBDIR}"
+    echo '{"imageLayoutVersion": "1.0.0"}' > "${RPM_OSTREE_OUTPUT_SUBDIR}/oci-layout"
+    echo '{"schemaVersion": 2, "manifests": []}' > "${RPM_OSTREE_OUTPUT_SUBDIR}/index.json"
+
     podman run --rm \
       --pull=never \
+      --mount=type=image,src="${target_image}:${tag}",target=/rpm-ostree \
       --privileged \
-      -v "/var/lib/containers:/var/lib/containers" \
+      -v "${RPM_OSTREE_OUTPUT_DIR}:/run/out:Z" \
       --entrypoint /usr/bin/rpm-ostree \
       "${RPM_OSTREE_CHUNKER_IMAGE}" \
       compose build-chunked-oci \
       --max-layers 127 \
       --format-version=2 \
       --bootc \
-      --from "localhost/${target_image}:${tag}" \
-      --output containers-storage:"localhost/${target_image}:${tag}"
+      --rootfs /rpm-ostree \
+      --output oci:/run/out/"${SUBDIR}":${tag}
+
+    CHUNKED_IMAGE="$(podman pull oci:"${RPM_OSTREE_OUTPUT_SUBDIR}")"
+    podman tag "${CHUNKED_IMAGE}" "${target_image}:${tag}"
 
 # Generate Default Tag
 [group('Utility')]


### PR DESCRIPTION
This is a way to use rpm-ostree inside a container without root
privileges during the build.

Fixes: https://github.com/ublue-os/image-template/issues/260
