### PR TITLE
feat: make rpm-ostree use containers-storage over oci-archive

### DIFF
--- a/Justfile
+++ b/Justfile
@@ -168,12 +168,17 @@ ostree-rechunk $target_image=image_name $tag=default_tag:
 
     set -xeuo pipefail
 
+    # Use the already-built local image to avoid pulling from a remote registry
+    RPM_OSTREE_CHUNKER_IMAGE="localhost/${target_image}:${tag}"
+
+    GRAPHROOT="$(podman info --format '{{{{.Store.GraphRoot}}')"
+
     podman run --rm --pull=never --privileged \
       --mount=type=image,src="${target_image}:${tag}",target=/rpm-ostree \
-      --mount=type=bind,src=/home/runner/.local/share/containers/storage,target=/run/host-container-storage,rw \
+      --mount=type=bind,src=${GRAPHROOT},target=/run/host-container-storage,rw \
       --mount=type=tmpfs,target=/run/rpm-ostree-storage \
       --entrypoint /usr/bin/rpm-ostree \
-      "localhost/${target_image}:${tag}" \
+      "${RPM_OSTREE_CHUNKER_IMAGE}" \
       compose build-chunked-oci \
       --max-layers 127 \
       --format-version=2 \

--- a/Justfile
+++ b/Justfile
@@ -168,29 +168,18 @@ ostree-rechunk $target_image=image_name $tag=default_tag:
 
     set -xeuo pipefail
 
-    # Use the already-built local image to avoid pulling from a remote registry
-    RPM_OSTREE_CHUNKER_IMAGE="localhost/${target_image}:${tag}"
-
-    RPM_OSTREE_OUTPUT_DIR="$(mktemp -d ./"${target_image}"_rpm-ostree_XXXXXX)"
-
-    trap 'rm -rf "${RPM_OSTREE_OUTPUT_DIR}"' EXIT
-
-    podman run --rm \
-      --pull=never \
+    podman run --rm --pull=never --privileged \
       --mount=type=image,src="${target_image}:${tag}",target=/rpm-ostree \
-      --privileged \
-      -v "${RPM_OSTREE_OUTPUT_DIR}:/run/out:Z" \
+      --mount=type=bind,src=/home/runner/.local/share/containers/storage,target=/run/host-container-storage,rw \
+      --mount=type=tmpfs,target=/run/rpm-ostree-storage \
       --entrypoint /usr/bin/rpm-ostree \
-      "${RPM_OSTREE_CHUNKER_IMAGE}" \
+      "localhost/${target_image}:${tag}" \
       compose build-chunked-oci \
       --max-layers 127 \
       --format-version=2 \
       --bootc \
       --rootfs /rpm-ostree \
-      --output oci-archive:/run/out/"${target_image}.oci"
-
-    CHUNKED_IMAGE="$(podman pull oci-archive:"${RPM_OSTREE_OUTPUT_DIR}/${target_image}.oci")"
-    podman tag "${CHUNKED_IMAGE}" "${target_image}:${tag}"
+      --output "containers-storage:[overlay@/run/host-container-storage+/run/rpm-ostree-storage]localhost/${target_image}:${tag}"
 
 # Generate Default Tag
 [group('Utility')]

--- a/Justfile
+++ b/Justfile
@@ -171,7 +171,7 @@ ostree-rechunk $target_image=image_name $tag=default_tag:
     # Use the already-built local image to avoid pulling from a remote registry
     RPM_OSTREE_CHUNKER_IMAGE="localhost/${target_image}:${tag}"
 
-    GRAPHROOT="$(podman info --format '{{{{.Store.GraphRoot}}')"
+    GRAPHROOT="$(podman info --format '{{ '{{.Store.GraphRoot}}' }}')"
 
     podman run --rm --pull=never --privileged \
       --mount=type=image,src="${target_image}:${tag}",target=/rpm-ostree \


### PR DESCRIPTION
Improves build performace on #261 by writing the image layers directly to the host container store instead of compressing to an OCI archive then decompressing before pushing to the registry.