### PR TITLE
chore: unpin bazzite

### DIFF
--- a/Containerfile
+++ b/Containerfile
@@ -4,7 +4,7 @@ COPY build_files /
 COPY system_files /system_files
 
 # Base Image
-FROM ghcr.io/ublue-os/bazzite:stable@sha256:b923f92d5a5b59eb992e269383eba2744601052da9d3d1595f76e79aa6ce2df0
+FROM ghcr.io/ublue-os/bazzite:stable
 ## Other possible base images include:
 # FROM ghcr.io/ublue-os/bazzite:testing
 # FROM ghcr.io/ublue-os/aurora:stable


### PR DESCRIPTION
While it is probably a good idea to pin this to a digest and setup renovate in the repo of the user to only build the image when the tag actually has received an update, instead of scheduling a build daily which results in useless rebuilds with no real changes as Bazzite (which I'm guessing is the most popular image) only updates week/bi-weekly'ish.

Renovate also doesn't currently update this image so sooner or later this image will get cleaned up and the builds here in the template will fail.

I'm not sure why exactly this got pinned, auto-approved and auto-merged in the first place in ffec79a8 by our hosted renovate.

IIRC there were some org-wide changes regarding that so that might be why?

If this was just a one-off thing then this is likely good enough to resolve it, if not then this probably needs a follow-up of some kind.