### PR TITLE
chore(ci): upgrade to ubuntu 26.04

### DIFF
--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -36,7 +36,7 @@ concurrency:
 jobs:
   build:
     name: Build disk images
-    runs-on: ${{ inputs.platform == 'amd64' && 'ubuntu-24.04' || 'ubuntu-24.04-arm' }}
+    runs-on: ${{ inputs.platform == 'amd64' && 'ubuntu-26.04' || 'ubuntu-26.04-arm' }}
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,7 +23,7 @@ concurrency:
 jobs:
   build_push:
     name: Build and push image
-    runs-on: ubuntu-24.04
+    runs-on: ubuntu-26.04
 
     permissions:
       contents: read


### PR DESCRIPTION
Due to varies issues caused by the recent podman upgrades done to the 24.04 runners [1]. We have been using 26.04 in Aurora since essentially day one and didn't have any major issues.

[1] https://github.com/ublue-os/bazzite/issues/5604#issuecomment-5432719347