### PR TITLE
chore: bump ublue-os/remove-unwanted-software

### DIFF
--- a/.github/workflows/build-disk.yml
+++ b/.github/workflows/build-disk.yml
@@ -70,7 +70,7 @@ jobs:
 
       - name: Maximize build space
         if: inputs.platform != 'arm64'
-        uses: ublue-os/remove-unwanted-software@cc0becac701cf642c8f0a6613bbdaf5dc36b259e # v9
+        uses: ublue-os/remove-unwanted-software@695eb75bc387dbcd9685a8e72d23439d8686cba6
         with:
           remove-codeql: true
 


### PR DESCRIPTION
This did not get picked up by renovate because v10 was never tagged.

This old commit of that action is no longer compatible with 26.04 runners and just breaks also this newer version is faster and better we should be using that anyway, we are already using it for the image build.

fixes: https://github.com/ublue-os/image-template/issues/269